### PR TITLE
feat(802): Add task name into team activity entry on the dashboard

### DIFF
--- a/app/Service/DashboardService.php
+++ b/app/Service/DashboardService.php
@@ -339,7 +339,7 @@ class DashboardService
     /**
      * Rhe 4 most recently active members of your team with member_id, name, description of the latest time entry, time_entry_id, task_id and a boolean status if the team member is currently working
      *
-     * @return array<int, array{member_id: string, name: string, description: string|null, time_entry_id: string, task_id: string|null, status: bool }>
+     * @return array<int, array{member_id: string, name: string, description: string|null, time_entry_id: string, task_id: string|null, task_name: string|null, status: bool }>
      */
     public function latestTeamActivity(Organization $organization): array
     {
@@ -353,6 +353,7 @@ class DashboardService
                 'member' => [
                     'user',
                 ],
+                'task',
             ])
             ->get()
             ->sortByDesc('start')
@@ -367,6 +368,7 @@ class DashboardService
                 'description' => $timeEntry->description,
                 'time_entry_id' => $timeEntry->id,
                 'task_id' => $timeEntry->task_id,
+                'task_name' => $timeEntry->task ? $timeEntry->task->name : null,
                 'status' => $timeEntry->end === null,
             ];
         }

--- a/resources/js/Components/Dashboard/TeamActivityCard.vue
+++ b/resources/js/Components/Dashboard/TeamActivityCard.vue
@@ -40,6 +40,7 @@ const { data: latestTeamActivity, isLoading } = useQuery({
                 :class="latestTeamActivity.length === 4 ? 'last:border-0' : ''"
                 :name="activity.name"
                 :description="activity.description"
+                :task-name="activity.task_name"
                 :working="activity.status"></TeamActivityCardEntry>
         </div>
         <div v-else class="text-center text-gray-500 py-8">

--- a/resources/js/Components/Dashboard/TeamActivityCardEntry.vue
+++ b/resources/js/Components/Dashboard/TeamActivityCardEntry.vue
@@ -2,6 +2,7 @@
 defineProps<{
     name: string;
     description: string | null;
+    taskName: string | null;
     working?: boolean;
 }>();
 </script>
@@ -31,7 +32,7 @@ defineProps<{
             </div>
             <div
                 class="text-text-secondary text-sm font-medium text-ellipsis whitespace-nowrap max-w-full overflow-hidden">
-                {{ description }}
+                {{ description || taskName }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Discussion in original repo
https://github.com/solidtime-io/solidtime/discussions/802

### What added
When a team member works on a task but does not use a description for time entry, it is unclear what task they work on.


<img width="657" alt="Screenshot 2025-05-30 at 16 07 51" src="https://github.com/user-attachments/assets/e0cf16e5-4670-4178-a1aa-dea34dd248b7" />
